### PR TITLE
makeTxDbFromGFF() has moved from GenomicFeatures to txdbmaker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SPLINTER
 Type: Package
 Title: Splice Interpreter of Transcripts
-Version: 1.13.3
-Date: 2020-03-23
+Version: 1.13.4
+Date: 2024-03-19
 Authors@R: person("Diana", "Low",  email = "lowdiana@gmail.com",
         role = c("aut", "cre"))
 URL: https://github.com/dianalow/SPLINTER/
@@ -23,4 +23,4 @@ Collate: primerpcr.R main_splinter.R
 Encoding: UTF-8
 RoxygenNote: 7.1.0
 VignetteBuilder: knitr
-Suggests: BiocStyle, knitr, rmarkdown
+Suggests: txdbmaker, BiocStyle, knitr, rmarkdown

--- a/man/acceptor.m.Rd
+++ b/man/acceptor.m.Rd
@@ -16,7 +16,7 @@ Acceptor site mammalian frequency matrices for GT-AG pairs from SpliceDB
   ..$ : chr [1:15] "V1" "V2" "V3" "V4" ...
 }
 \source{
-url{http://www.softberry.com/spldb/SpliceDB.html}
+\url{http://www.softberry.com/spldb/SpliceDB.html}
 }
 \references{
 Burset M., Seledtsov I., Solovyev V. (Nucl.Acids Res.,2000,28,4364-4375; Nucl. Acids Res.,2001,29,255-259)

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -43,6 +43,7 @@ object.
 ```{r,message=FALSE}
 data_path<-system.file("extdata",package="SPLINTER")
 gtf_file<-paste(data_path,"/Mus_musculus.Ensembl.NCBIM37.65.partial.gtf",sep="")
+library(txdbmaker)
 txdb <- makeTxDbFromGFF(file=gtf_file,chrominfo = Seqinfo(genome="mm9"))
 
 # txdb generation can take quite long, you can save the object and load it the next time


### PR DESCRIPTION
This PR fixes the ERROR we see on the [Bioconductor daily builds](https://bioconductor.org/checkResults/3.19/bioc-LATEST/SPLINTER/) on nebbiolo1 (Intel Linux builder).

Best,
H.